### PR TITLE
Add CI pipeline

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -1,0 +1,25 @@
+name: Autotools CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: install autotools
+      run: sudo apt install autoconf libtool
+    - name: autogen
+      run: ./autogen.sh
+    - name: configure
+      run: ./configure
+    - name: make
+      run: make
+    - name: make check
+      run: make check


### PR DESCRIPTION
GitHub can run tests with every commit.  On other projects having a good CI pipeline helped me troubleshoot difficult issues:
https://github.blog/2019-08-08-github-actions-now-supports-ci-cd/